### PR TITLE
exist member login fail solved + partyId (Integer -> String)

### DIFF
--- a/src/main/java/com/moyeobwayo/moyeobwayo/Controller/UserController.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Controller/UserController.java
@@ -1,6 +1,7 @@
 package com.moyeobwayo.moyeobwayo.Controller;
 
 import com.moyeobwayo.moyeobwayo.Domain.UserEntity;
+import com.moyeobwayo.moyeobwayo.Domain.response.UserResponse;
 import com.moyeobwayo.moyeobwayo.Service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +27,7 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<?> loginUser(@RequestBody UserLoginRequest request) {
         // 서비스 호출하여 사용자 인증
-        Optional<UserEntity> user = userService.login(request.getUserName(), request.getPassword(), request.getPartyId(), request.isKakao());
+        Optional<UserResponse> user = userService.loginOrRegister(request.getUserName(), request.getPassword(), request.getPartyId(), request.isKakao());
 
         if (user.isPresent()) {
             // 로그인 성공 시, 사용자 정보를 반환

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Domain/response/UserResponse.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Domain/response/UserResponse.java
@@ -1,0 +1,17 @@
+package com.moyeobwayo.moyeobwayo.Domain.response;
+
+import com.moyeobwayo.moyeobwayo.Domain.UserEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserResponse {
+    private UserEntity user;
+    private String message;
+
+    public UserResponse(UserEntity user, String message) {
+        this.user = user;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Repository/UserEntityRepository.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Repository/UserEntityRepository.java
@@ -15,31 +15,17 @@ public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
     List<UserEntity> findUserEntitiesByParty(Party party);
 
     @Query("SELECT u.kakaoProfile.kakaoUserId FROM UserEntity u WHERE u.party.partyId = :partyId")
-    Optional<Long> findKakaoIDByPartyId(@Param("partyId") String partyId);
+    Optional<Long> findKakaoIDByPartyId(@Param("partyId") String partyId); // ★ partyId가 String으로 처리됨
 
-
-
-    // 특정 이름과 Party ID로 UserEntity 찾기
-    // 수정된 쿼리 메서드: @Param 어노테이션의 변수명을 정확히 맞춤
+    // ★ 파티 ID가 String으로 처리되도록 변경
     @Query("SELECT u FROM UserEntity u WHERE u.user_name = :user_name AND u.party.partyId = :partyId")
     Optional<UserEntity> findUserInSameParty(@Param("user_name") String user_name, @Param("partyId") String partyId);
 
-    // 특정 ID와 Party ID로 UserEntity 찾기
+    // ★ 파티 ID가 String으로 처리되도록 변경
     @Query("SELECT u FROM UserEntity u WHERE u.user_id = :currentUserId AND u.party.partyId = :partyId")
     Optional<UserEntity> findByIdAndPartyId(@Param("currentUserId") int currentUserId, @Param("partyId") String partyId);
 
-//    @Query("SELECT u FROM KakaoProfile u WHERE u.kakaoUserId = :currentUserId AND u.party.party_id = :partyId")
-//    Optional<UserEntity> findByPartyIdAndKakaoUserId(@Param("currentUserId") int currentUserId, @Param("partyId") String partyId);
-
-
-    //Optional<UserEntity> findByKakaoProfile_KakaoUserId(Long kakaoUserId); // Optional로 변경
-
-
-//    @Query("SELECT u.party FROM UserEntity u WHERE u.kakaoProfile.kakao_user_id = :kakaoUserId")
-  //  List<Party> findUserEntitiesPartiesByKakaoProfile_KakaoUserId(@Param("kakaoUserId") Long kakaoUserId);
     List<UserEntity> findUserEntitiesByKakaoProfile_KakaoUserId(Long kakaoUserId);
 
     Optional<UserEntity> findByKakaoProfile_KakaoUserId(Long kakaoUserId);
-//파티 리스트를 KakaoProfile_KakaoUserId 를 통해 가져오고싶어
-
-    }
+}

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Service/UserService.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Service/UserService.java
@@ -3,6 +3,7 @@ package com.moyeobwayo.moyeobwayo.Service;
 import com.moyeobwayo.moyeobwayo.Domain.Alarm;
 import com.moyeobwayo.moyeobwayo.Domain.Party;
 import com.moyeobwayo.moyeobwayo.Domain.UserEntity;
+import com.moyeobwayo.moyeobwayo.Domain.response.UserResponse;
 import com.moyeobwayo.moyeobwayo.Repository.AlarmRepository;
 import com.moyeobwayo.moyeobwayo.Repository.PartyRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,14 +12,13 @@ import com.moyeobwayo.moyeobwayo.Repository.UserEntityRepository;
 
 import java.util.Optional;
 
-
 @Service
 @Transactional
 public class UserService {
 
     private final UserEntityRepository userRepository;
     private final PartyRepository partyRepository;
-    private final AlarmRepository alarmRepository;  // 알람 리포지토리 추가
+    private final AlarmRepository alarmRepository; // 알람 리포지토리 추가
 
     public UserService(UserEntityRepository userRepository, PartyRepository partyRepository, AlarmRepository alarmRepository) {
         this.userRepository = userRepository;
@@ -27,47 +27,46 @@ public class UserService {
     }
 
     // 로그인 로직: 파티 내 중복 이름 확인 및 로그인 처리
-
-    public Optional<UserEntity> login(String userName, String password, String partyId, boolean isKakao) {
+    public Optional<UserResponse> loginOrRegister(String userName, String password, String partyId, boolean isKakao) {
         // 파티 ID로 해당 파티 조회
         Optional<Party> partyOptional = partyRepository.findById(partyId);
         if (partyOptional.isEmpty()) {
-            return Optional.empty();  // 해당 파티가 존재하지 않음
+            return Optional.empty(); // 해당 파티가 존재하지 않음
         }
-        Party party = partyOptional.get();  // 파티가 존재하면 파티 객체를 가져옴
+        Party party = partyOptional.get(); // 파티가 존재하면 파티 객체를 가져옴
 
-        // 해당 파티에 중복된 이름 확인
+        // 기존 사용자 확인
         Optional<UserEntity> existingUser = userRepository.findUserInSameParty(userName, partyId);
         if (existingUser.isPresent()) {
-            return Optional.empty();  // 중복된 이름이 있는 경우 로그인 실패
+            // 기존 사용자가 있으면 비밀번호 확인 후 로그인 처리
+            UserEntity user = existingUser.get();
+            // ✨ 기존 when2meet 로직과 최대한 비슷하게 처리
+            if (password == null || password.equals(user.getPassword())) {
+                // [알고리즘]비밀번호가 없거나, 작성시에 같으면 로그인 성공
+                return Optional.of(new UserResponse(user, "기존 회원 로그인이 완료되었습니다."));
+            } else {
+                return Optional.empty(); // 비밀번호 불일치로 로그인 실패
+            }
         }
 
-        // 새로운 사용자 생성 및 파티 연관 관계 설정
+        // 사용자가 없으면 새로 회원가입 (회원가입 기능)
         UserEntity newUser = new UserEntity();
         newUser.setUser_name(userName);
         newUser.setPassword(password);
-        newUser.setParty(party);  // 파티와의 관계 설정
+        newUser.setParty(party);
 
-        // 새로운 사용자 저장
+        // 새로운 사용자는 DB에 저장.
         newUser = userRepository.save(newUser);
 
-        // 🌟 만약 isKakao가 true라면 알람 테이블에 새로운 알람 추가
         if (isKakao) {
-            System.out.println("Creating new Alarm object...");
             Alarm newAlarm = new Alarm();
             newAlarm.setUserEntity(newUser);
             newAlarm.setParty(party);
             newAlarm.setAlarm_on(true);
 
-            // 저장 전 알람 객체 정보 확인
-            System.out.println("Alarm Details: User ID: " + newAlarm.getUserEntity().getUser_id() + ", Party ID: " + newAlarm.getParty().getPartyId());
-
-            // 저장 시도
             alarmRepository.save(newAlarm);
-            System.out.println("Alarm saved successfully!");
         }
 
-        // 사용자 정보를 반환
-        return Optional.of(newUser);
+        return Optional.of(new UserResponse(newUser, "신규 회원이 데이터베이스에 저장되었습니다."));
     }
 }


### PR DESCRIPTION
기존 회원이 로그인 시, 로그인단계에서 튕겨버리던 오류 수정
User의 모든 코드 中, partyId를 다루는 코드 (Integer -> String)으로 수정

---

<img width="332" alt="같은이름없을시" src="https://github.com/user-attachments/assets/0e246ef0-7466-4081-a48b-9fa4016719f1">
<img width="337" alt="같은이름존재시" src="https://github.com/user-attachments/assets/22c4addb-5700-41ac-895e-2e4bace73fac">

-> 이제 로그인 시, 존재하지 않는 이름이라면 "신규 회원이 데이터베이스에 저장되었습니다." 라는 메세지가 출력되고,
이미 존재하는 회원이라면 "기존 회원 로그인이 완료되었습니다." 라는 메세지가 함께 출력됩니다.