### PR TITLE
Fix/meetlist

### DIFF
--- a/src/main/java/com/moyeobwayo/moyeobwayo/Controller/KakaoUserPartyController.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Controller/KakaoUserPartyController.java
@@ -16,6 +16,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.ErrorResponse;
@@ -48,8 +50,8 @@ public class KakaoUserPartyController {
     public ResponseEntity<?> getPartyByKakaoUserId(@RequestBody GetMeetListByKakaoIdRequest reqData) {
         try {
             // 서비스에서 kakao_user_id로 Party 조회
-            Long KakaoUserId = (long) reqData.getKakaoUserId(); // kakaoUserId를 받아옴
-            List<Party> parties = kakaoUserPartyService.getPartyByKakaoUserId(KakaoUserId); // kakaoUserId를 기반으로 파티 조회
+            Pageable pageable = PageRequest.of(reqData.getPage() - 1, reqData.getSize());
+            List<Party> parties = kakaoUserPartyService.getPartyByKakaoUserId(reqData.getKakaoUserId(), pageable);
             return ResponseEntity.ok(parties);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(404).body(e.getMessage());

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Controller/KakaoUserPartyController.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Controller/KakaoUserPartyController.java
@@ -38,12 +38,18 @@ public class KakaoUserPartyController {
         this.partyService = partyService;
     }
 
+    /**
+     * POST /api/v1/kakaouser/meetlist
+     * 카카오 사용자 id로 파티 조회
+     * @param reqData
+     * @return
+     */
     @PostMapping("/meetlist")
     public ResponseEntity<?> getPartyByKakaoUserId(@RequestBody GetMeetListByKakaoIdRequest reqData) {
         try {
             // 서비스에서 kakao_user_id로 Party 조회
-            Long KakaoUserId = (long) reqData.getKakaoUserId();
-            List<Party> parties = kakaoUserPartyService.getPartyByKakaoUserId(KakaoUserId);
+            Long KakaoUserId = (long) reqData.getKakaoUserId(); // kakaoUserId를 받아옴
+            List<Party> parties = kakaoUserPartyService.getPartyByKakaoUserId(KakaoUserId); // kakaoUserId를 기반으로 파티 조회
             return ResponseEntity.ok(parties);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(404).body(e.getMessage());

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Domain/request/GetMeetListByKakaoIdRequest.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Domain/request/GetMeetListByKakaoIdRequest.java
@@ -9,6 +9,6 @@ import lombok.Setter;
 @NoArgsConstructor @AllArgsConstructor
 public class GetMeetListByKakaoIdRequest {
     private Long kakaoUserId;
-
-
+    private int page;  // 요청 페이지 번호
+    private int size;  // 한 페이지당 데이터 개수
 }

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Repository/UserEntityRepository.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Repository/UserEntityRepository.java
@@ -2,6 +2,8 @@ package com.moyeobwayo.moyeobwayo.Repository;
 
 import com.moyeobwayo.moyeobwayo.Domain.Party;
 import com.moyeobwayo.moyeobwayo.Domain.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -30,4 +32,7 @@ public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByKakaoProfile_KakaoUserId(Long kakaoUserId);
 
     List<UserEntity> findAllByParty_PartyId(String partyId);
+
+    // kakaoUserId 기준으로 UserEntity를 페이징 처리하여 조회
+    Page<UserEntity> findByKakaoProfile_KakaoUserId(Long kakaoUserId, Pageable pageable);
 }

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Service/KakaoUserPartyService.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Service/KakaoUserPartyService.java
@@ -4,6 +4,7 @@ import com.moyeobwayo.moyeobwayo.Domain.Party;
 import com.moyeobwayo.moyeobwayo.Domain.UserEntity;
 import com.moyeobwayo.moyeobwayo.Repository.UserEntityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -26,16 +27,15 @@ public class KakaoUserPartyService {
      * @param kakaoUserId
      * @return
      */
-    public List<Party> getPartyByKakaoUserId(Long kakaoUserId) {
+    public List<Party> getPartyByKakaoUserId(Long kakaoUserId, Pageable pageable) {
         // kakao_user_id로 UserEntity 조회
-        List<UserEntity> userEntity = userEntityRepository.findUserEntitiesByKakaoProfile_KakaoUserId(kakaoUserId);
+        List<UserEntity> userEntities = userEntityRepository.findByKakaoProfile_KakaoUserId(kakaoUserId, pageable).getContent();
 
-        if (userEntity.isEmpty()) {
-            return null;
-        }
         List<Party> partyList = new ArrayList<>();
-        for (UserEntity userEntity1 : userEntity) {
-            partyList.add(userEntity1.getParty());
+        for (UserEntity userEntity : userEntities) {
+            if (userEntity.getParty() != null) {
+                partyList.add(userEntity.getParty());
+            }
         }
 
         /*
@@ -47,7 +47,6 @@ public class KakaoUserPartyService {
 
 
         return distinctPartyList;
-        // return partyList;
 
     }
 }

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Service/KakaoUserPartyService.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Service/KakaoUserPartyService.java
@@ -7,7 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class KakaoUserPartyService {
@@ -19,10 +21,14 @@ public class KakaoUserPartyService {
         this.userEntityRepository = userEntityRepository;
     }
 
+    /**
+     *
+     * @param kakaoUserId
+     * @return
+     */
     public List<Party> getPartyByKakaoUserId(Long kakaoUserId) {
         // kakao_user_id로 UserEntity 조회
         List<UserEntity> userEntity = userEntityRepository.findUserEntitiesByKakaoProfile_KakaoUserId(kakaoUserId);
-
 
         if (userEntity.isEmpty()) {
             return null;
@@ -30,9 +36,18 @@ public class KakaoUserPartyService {
         List<Party> partyList = new ArrayList<>();
         for (UserEntity userEntity1 : userEntity) {
             partyList.add(userEntity1.getParty());
-
         }
-        return partyList;
+
+        /*
+        파티가 중복되는 문제가 발생한다고 했는데 로직 상 그럴만한 부분을 찾지 못해 Set으로 변경해서
+        중복 제거하고 다시 ArrayList로 변환시키는 방법을 사용했습니다.(donggeun)
+         */
+        Set<Party> partySet = new HashSet<>(partyList);
+        List<Party> distinctPartyList = new ArrayList<>(partySet);
+
+
+        return distinctPartyList;
+        // return partyList;
 
     }
 }


### PR DESCRIPTION
1. meetlist 중복 제거했습니다.
(어느 부분에서 중복이 발생하는지 원인은 못 찾았는데 발생했다고 해서, set으로 변경 후 다시 list로 바꾸는 방식으로 중복값이 절대 발생할 수 없게 수정했습니다.)

2. paging처리 완료했습니다.
(프론트에서 meetlist에 요청할 때, json으로 보내는 양식이 바뀌었습니다.)
e.g.
{
  "kakaoUserId": 1001,
  "page": 2,
  "size": 20
}

해당 기능들 추가하기 전에 테스트 겸 meetlist에 요청 보내면 데이터베이스 순서대로 안오고 엉망으로 오던데, 프론트에서는 해결된 문제인가요?(이 부분은 따로 처리하지 않았습니다. 수정된 코드도 이전과 동일하게 순서대로 안 옴.)