### PR TITLE
fix: 알림톡 동시성 에러 해결

### DIFF
--- a/src/main/java/com/moyeobwayo/moyeobwayo/Domain/Party.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Domain/Party.java
@@ -35,7 +35,6 @@ public class Party {
     private String userId; // 새롭게 추가
 
     private boolean messageSend = false; // 메세지 전송 여부
-
     @OneToMany(mappedBy = "party")
     //@JsonIgnore  // 순환 참조 방지
     private List<Alarm> alarms;

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Domain/dto/PartyResponseDTO.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Domain/dto/PartyResponseDTO.java
@@ -8,10 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @AllArgsConstructor
@@ -29,7 +26,7 @@ public class PartyResponseDTO {
         // 기존 코드: this.party.getDates().sort(Comparator.comparing(DateEntity::getSelected_date));
         List<DateEntity> sortedDates = new ArrayList<>(this.party.getDates()); // Set -> List 변환
         sortedDates.sort(Comparator.comparing(DateEntity::getSelected_date)); // 정렬 수행
-        this.party.setDates(new HashSet<>(sortedDates)); // 정렬된 데이터를 다시 Set으로 저장 (필요한 경우)
+        this.party.setDates(new LinkedHashSet<>(sortedDates)); // 정렬된 데이터를 다시 Set으로 저장 (필요한 경우)
 
         // Timeslot 정보를 원하는 형식으로 변환하여 날짜별로 저장
         sortedDates.forEach(date -> { // 기존 코드: this.party.getDates().forEach(date -> {

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Repository/DateEntityRepsitory.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Repository/DateEntityRepsitory.java
@@ -1,7 +1,10 @@
 package com.moyeobwayo.moyeobwayo.Repository;
 
 import com.moyeobwayo.moyeobwayo.Domain.DateEntity;
+import com.moyeobwayo.moyeobwayo.Domain.Party;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -10,4 +13,8 @@ import java.util.Date;
 public interface DateEntityRepsitory extends JpaRepository<DateEntity, Long> {
     @Query("SELECT d.dateId FROM DateEntity d WHERE d.party.partyId = :partyId AND FUNCTION('DATE', d.selected_date) = FUNCTION('DATE', :selectedDate)")
     Integer findDateIdByPartyAndSelectedDate(@Param("partyId") String partyId, @Param("selectedDate") Date selectedDate);
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("SELECT d.party FROM DateEntity d WHERE d.dateId = :dateId")
+    Party findPartyByDateIdWithLock(@Param("dateId") Long dateId);
 }

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Service/PartyService.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Service/PartyService.java
@@ -63,14 +63,11 @@ public class PartyService {
      * 알림톡 예약 전송 10분 (테스트 3초)
      */
     public void scheduleAlimTalk(Party party) {
-        scheduler.schedule(() -> {
-            try {
-                sendAlimTalkToPartyCreator(party.getPartyId());
-            } catch (Exception e) {
-                System.err.println("알림톡 전송 실패: " + e.getMessage());
-            }
-        }, 10 * 60, TimeUnit.SECONDS);
-        //}, 10, TimeUnit.MINUTES); // 10분 후 실행
+        try {
+            sendAlimTalkToPartyCreator(party.getPartyId());
+        } catch (Exception e) {
+            System.err.println("알림톡 전송 실패: " + e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/com/moyeobwayo/moyeobwayo/Service/kakaotalkalarmService.java
+++ b/src/main/java/com/moyeobwayo/moyeobwayo/Service/kakaotalkalarmService.java
@@ -68,6 +68,16 @@ public class kakaotalkalarmService {
             msgObj.put("plusFriendId", plusFriendId);
             msgObj.put("templateCode", templateCode);
 
+            //reserved Time 필드 등록
+            int delayTimeInMinutes = 11;
+            LocalDateTime reserveTime = LocalDateTime.now().plusMinutes(delayTimeInMinutes);
+            // 2. 포맷 지정
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            // 3. reserveTime을 지정된 포맷으로 문자열 변환
+            String formattedTime = reserveTime.format(formatter);
+            // 4. reserveTime을 msgObj에 설정
+            msgObj.put("reserveTime", formattedTime);
+
             // 메시지 내용 구성
             JSONObject messages = new JSONObject();
             messages.put("countryCode", "82");  // 국가 코드

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     hibernate:
       ddl-auto: update  # 테이블 자동 생성 및 업데이트
       # ddl-auto: create # 기존 테이블 삭제 후 새로 생성
-    show-sql: true  # SQL 쿼리 로그 콘솔 출력
+    show-sql: false  # SQL 쿼리 로그 콘솔 출력
   datasource:
     hikari:
       maximum-pool-size: 4


### PR DESCRIPTION
기존 로직 : 파티 투표시에 curNum === targetNum시점에서 알림톡을 발송하는 로직
문제상황 : 
1) 트래픽이 몰리게되면 DB에서 party.curNum의 값이 다 다르게 불러옴
2) 따라서 정확하지않은 curNum 때문에 알림톡이 무한대로 오는 에러 발견

해결 방식 :
비관적 락을 통해서 파티 투표시 date로부터 파티를 불러올 때 락을 설정함